### PR TITLE
Resolve unknown variable message in puppetserver logs

### DIFF
--- a/manifests/license/available.pp
+++ b/manifests/license/available.pp
@@ -13,7 +13,7 @@ class em_utils::license::available(
 
   file { 'EM entitlements':
     ensure  => 'directory',
-    path    => "${puppet_confdir}/${path}",
+    path    => "${::puppet_confdir}/${path}",
     source  => "puppet://${server}/modules/${path}",
     recurse => true,
   }


### PR DESCRIPTION
At Schufa, we are stumbling across messages like 

> 2019-06-11T00:55:23.507+02:00 WARN  [qtp1195761933-462498] [puppetserver] Puppet Unknown variable: 'puppet_confdir'. (file: /etc/puppetlabs/code/environments/dev_sys0/modules/em_utils/manifests/license/available.pp, line: 16, column: 19)

running on a fairly recent puppet 6 installation. 
As puppet_confdir is a fact, using either $facts['puppet_confdir'] or $::puppet_confdir should solve the issue